### PR TITLE
Enhance SnetDashboard and WorkgroupBalances components to support archived workgroups

### DIFF
--- a/components/SnetDashboard.tsx
+++ b/components/SnetDashboard.tsx
@@ -26,6 +26,7 @@ import {
   filterIncomingTransactions,
   isTransactionInSpecialReturnedGroup
 } from '../utils/transactionUtils';
+import { mergeSubgroupRowsByCanonicalName } from '../utils/workgroupUtils';
 
 interface SnetDashboardProps {
   query: {
@@ -72,6 +73,7 @@ interface ProcessedDataType {
 
 interface WorkgroupBudget {
   sub_group: string;
+  archived?: boolean | null;
   sub_group_data: {
     budgets: Record<string, Record<string, {
       initial: { AGIX: number };
@@ -181,8 +183,7 @@ const SnetDashboard: React.FC<SnetDashboardProps> = ({ query }) => {
               : item.sub_group_data
           };
         });
-        //console.log('Processed data:', processedData);
-        return processedData;
+        return mergeSubgroupRowsByCanonicalName(processedData);
       } else {
         console.error('Unexpected data format from getSubgroups:', data);
         return [];

--- a/components/WorkgroupBalances.tsx
+++ b/components/WorkgroupBalances.tsx
@@ -1,5 +1,5 @@
 // ../components/WorkgroupBalances.tsx
-import React from 'react';
+import React, { useState } from 'react';
 import styles from '../styles/WorkgroupBalances.module.css';
 import * as WorkgroupUtils from '../utils/workgroupUtils';
 
@@ -20,14 +20,23 @@ const WorkgroupBalances: React.FC<WorkgroupBalancesProps> = ({
   allDistributions,
   selectedQuarterFilters,
 }) => {
+  const [archivedExpanded, setArchivedExpanded] = useState(false);
   const { quarters, years } = WorkgroupUtils.getQuartersAndYearsFromMonths(months);
 
   let workgroupsToRender: string[] = [];
   if (workgroupsBudgets) {
     workgroupsToRender = selectedWorkgroups.includes('All workgroups')
       ? workgroupsBudgets.map((wg: WorkgroupUtils.WorkgroupBudget) => wg.sub_group)
-      : selectedWorkgroups;
+      : selectedWorkgroups.filter((w) => w !== 'All workgroups');
     workgroupsToRender.sort((a, b) => a.localeCompare(b));
+  }
+
+  const activeWorkgroupNames: string[] = [];
+  const archivedWorkgroupNames: string[] = [];
+  for (const name of workgroupsToRender) {
+    const wg = workgroupsBudgets.find((w) => w.sub_group === name);
+    const isArchived = wg?.archived === true;
+    (isArchived ? archivedWorkgroupNames : activeWorkgroupNames).push(name);
   }
 
   const totalBudget = workgroupsToRender.reduce((sum, workgroupName) => {
@@ -59,6 +68,40 @@ const WorkgroupBalances: React.FC<WorkgroupBalancesProps> = ({
     return sum + (workgroup ? WorkgroupUtils.getCumulativeRemainingForWorkgroup(workgroup, months, data, selectedQuarterFilters) : 0);
   }, 0);
 
+  const renderWorkgroupRow = (workgroupName: string, rowKey: string) => {
+    const workgroup = workgroupsBudgets.find((wg) => wg.sub_group === workgroupName);
+    if (!workgroup) return null;
+
+    const budget = Math.round(WorkgroupUtils.getBudgetForWorkgroup(workgroup, quarters, years));
+    const spent = Math.round(WorkgroupUtils.getSpentForWorkgroup(workgroupName, months, data));
+    const incomingReallocation = Math.round(
+      WorkgroupUtils.getReallocationForWorkgroup(workgroup, quarters, years, 'incoming', selectedQuarterFilters)
+    );
+    const outgoingReallocation = Math.round(
+      WorkgroupUtils.getReallocationForWorkgroup(workgroup, quarters, years, 'outgoing', selectedQuarterFilters)
+    );
+    const remaining = budget - spent + incomingReallocation - outgoingReallocation;
+    const cumulativeReallocation = Math.round(
+      WorkgroupUtils.getCumulativeReallocationForWorkgroup(workgroup, quarters, years, selectedQuarterFilters)
+    );
+    const cumulativeRemaining = Math.round(
+      WorkgroupUtils.getCumulativeRemainingForWorkgroup(workgroup, months, data, selectedQuarterFilters)
+    );
+
+    return (
+      <tr key={rowKey}>
+        <td>{workgroupName}</td>
+        <td>{budget}</td>
+        <td>{spent}</td>
+        <td>{incomingReallocation}</td>
+        <td>{outgoingReallocation}</td>
+        <td>{remaining}</td>
+        <td>{cumulativeReallocation}</td>
+        <td>{cumulativeRemaining}</td>
+      </tr>
+    );
+  };
+
   return (
     <div className={styles.numbers}>
       <table>
@@ -75,31 +118,27 @@ const WorkgroupBalances: React.FC<WorkgroupBalancesProps> = ({
           </tr>
         </thead>
         <tbody>
-          {workgroupsToRender.map((workgroupName, rowIndex) => {
-            const workgroup = workgroupsBudgets.find(wg => wg.sub_group === workgroupName);
-            if (!workgroup) return null;
-
-            const budget = Math.round(WorkgroupUtils.getBudgetForWorkgroup(workgroup, quarters, years));
-            const spent = Math.round(WorkgroupUtils.getSpentForWorkgroup(workgroupName, months, data));
-            const incomingReallocation = Math.round(WorkgroupUtils.getReallocationForWorkgroup(workgroup, quarters, years, 'incoming', selectedQuarterFilters));
-            const outgoingReallocation = Math.round(WorkgroupUtils.getReallocationForWorkgroup(workgroup, quarters, years, 'outgoing', selectedQuarterFilters));
-            const remaining = budget - spent + incomingReallocation - outgoingReallocation;
-            const cumulativeReallocation = Math.round(WorkgroupUtils.getCumulativeReallocationForWorkgroup(workgroup, quarters, years, selectedQuarterFilters));
-            const cumulativeRemaining = Math.round(WorkgroupUtils.getCumulativeRemainingForWorkgroup(workgroup, months, data, selectedQuarterFilters));
-
-            return (
-              <tr key={rowIndex}>
-                <td>{workgroupName}</td>
-                <td>{budget}</td>
-                <td>{spent}</td>
-                <td>{incomingReallocation}</td>
-                <td>{outgoingReallocation}</td>
-                <td>{remaining}</td>
-                <td>{cumulativeReallocation}</td>
-                <td>{cumulativeRemaining}</td>
+          {activeWorkgroupNames.map((workgroupName) => renderWorkgroupRow(workgroupName, workgroupName))}
+          {archivedWorkgroupNames.length > 0 && (
+            <>
+              <tr className={styles.archivedToggleRow}>
+                <td colSpan={8}>
+                  <button
+                    type="button"
+                    className={styles.archivedToggle}
+                    onClick={() => setArchivedExpanded((open) => !open)}
+                    aria-expanded={archivedExpanded}
+                  >
+                    {archivedExpanded ? '▼' : '▶'} Archived workgroups ({archivedWorkgroupNames.length})
+                  </button>
+                </td>
               </tr>
-            );
-          })}
+              {archivedExpanded &&
+                archivedWorkgroupNames.map((workgroupName) =>
+                  renderWorkgroupRow(workgroupName, `archived-${workgroupName}`)
+                )}
+            </>
+          )}
           <tr>
             <td>Totals</td>
             <td>{Math.round(totalBudget)}</td>

--- a/pages/api/getSubgroups.js
+++ b/pages/api/getSubgroups.js
@@ -26,7 +26,7 @@ async function getSubGroups( project_id) {
   // Fetch all existing SubGroups from the database
   const { data: existingSubGroups, error: fetchError } = await supabase
     .from("subgroups")
-    .select("sub_group, budgets, sub_group_data")
+    .select("sub_group, budgets, sub_group_data, archived")
     .eq('project_id', project_id);
 
   if (fetchError) throw fetchError;

--- a/styles/WorkgroupBalances.module.css
+++ b/styles/WorkgroupBalances.module.css
@@ -98,6 +98,36 @@
     text-align: right;
 }
 
+/* Dark-theme friendly: avoid light gray (reads as white) with inherited light text */
+.archivedToggleRow td {
+    padding: 0;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.archivedToggle {
+    display: block;
+    width: 100%;
+    margin: 0;
+    padding: 10px 8px;
+    border: none;
+    background: transparent;
+    font: inherit;
+    font-size: 0.8rem;
+    text-align: left;
+    cursor: pointer;
+    color: rgb(255, 255, 255);
+}
+
+.archivedToggle:hover {
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.archivedToggle:focus-visible {
+    outline: 2px solid rgba(255, 255, 255, 0.6);
+    outline-offset: -2px;
+}
+
 .workgroupContainer {
     display: flex;
     flex-wrap: wrap;

--- a/utils/getReport.js
+++ b/utils/getReport.js
@@ -1,3 +1,5 @@
+import { canonicalWorkgroupName } from './workgroupUtils';
+
 export async function getReport(txs) {
   
   async function generateReport() {
@@ -13,7 +15,7 @@ export async function getReport(txs) {
     if (tx.tx_type === "Outgoing") {
       tx.contributions.forEach(contribution => {
         let workgroup = contribution.task_sub_group || "not-recorded";
-        workgroup = workgroup.replace(/ /g, '-').toLowerCase();
+        workgroup = canonicalWorkgroupName(workgroup);
         
         let taskDateStr = contribution.task_date || tx.transaction_date.toString();
         if(contribution.task_date) {

--- a/utils/processDashboardData.js
+++ b/utils/processDashboardData.js
@@ -1,3 +1,5 @@
+import { distributionMatchesWorkgroupSelection } from './workgroupUtils';
+
 export function processDashboardData(selectedMonths, selectedWorkgroups, selectedTokens, selectedLabels, distributionsArray, core_token) {
     //console.log(distributionsArray, core_token);
     const filteredDistributions = distributionsArray.filter(distribution => {
@@ -10,7 +12,7 @@ export function processDashboardData(selectedMonths, selectedWorkgroups, selecte
         const isMonthMatch = selectedMonths.includes('All months') || selectedMonths.includes(formattedTaskDate);
 
         // Check if the distribution matches the selected workgroups
-        const isWorkgroupMatch = selectedWorkgroups.includes('All workgroups') || selectedWorkgroups.includes(distribution.task_sub_group);
+        const isWorkgroupMatch = distributionMatchesWorkgroupSelection(distribution.task_sub_group, selectedWorkgroups);
 
         // Check if the distribution matches the selected tokens
         const isTokenMatch = selectedTokens.includes('All tokens') || distribution.tokens.some(token => selectedTokens.includes(token));

--- a/utils/processSnetDashboardData.js
+++ b/utils/processSnetDashboardData.js
@@ -1,4 +1,6 @@
 // ../utils/processSnetDashboardData.js
+import { distributionMatchesWorkgroupSelection } from './workgroupUtils';
+
 export function processDashboardData(selectedMonths, selectedWorkgroups, selectedTokens, selectedLabels, distributionsArray, budgets) {
 
     const filteredDistributions = distributionsArray.filter(distribution => {
@@ -11,7 +13,7 @@ export function processDashboardData(selectedMonths, selectedWorkgroups, selecte
         const isMonthMatch = selectedMonths.includes('All months') || selectedMonths.includes(formattedTaskDate);
 
         // Check if the distribution matches the selected workgroups
-        const isWorkgroupMatch = selectedWorkgroups.includes('All workgroups') || selectedWorkgroups.includes(distribution.task_sub_group);
+        const isWorkgroupMatch = distributionMatchesWorkgroupSelection(distribution.task_sub_group, selectedWorkgroups);
 
         // Check if the distribution matches the selected tokens
         const isTokenMatch = selectedTokens.includes('All tokens') || distribution.tokens.some(token => selectedTokens.includes(token));
@@ -554,7 +556,7 @@ function createTable1Data(filteredDistributions) {
                         const amount = Number(distribution.amounts[index]);
                         monthlyTotals[month][token] = (Number(monthlyTotals[month][token]) || 0) + amount;
     
-                        if (workgroup && (selectedWorkgroups.includes(workgroup) || selectedWorkgroups.includes('All workgroups'))) {
+                        if (workgroup && distributionMatchesWorkgroupSelection(workgroup, selectedWorkgroups)) {
                             if (!workgroupTotals[workgroup]) {
                                 workgroupTotals[workgroup] = {};
                             }

--- a/utils/specWorkgroupCompUtils.ts
+++ b/utils/specWorkgroupCompUtils.ts
@@ -1,3 +1,5 @@
+import { canonicalWorkgroupName } from './workgroupUtils';
+
 export const formatNumberWithLeadingZero = (num: number): string => {
     return num < 10 ? `0${num}` : `${num}`;
   };
@@ -11,9 +13,9 @@ export const formatNumberWithLeadingZero = (num: number): string => {
   export const filterContributionsByWorkgroupAndMonth = (transactions: any[], workgroup: string, formattedSelectedMonth: string) => {
     const curatedContributions = transactions.flatMap((transaction: any) => 
       transaction.contributions ? transaction.contributions.filter((contribution: any) => {
-        // Check if the contribution belongs to the selected workgroup
+        // Check if the contribution belongs to the selected workgroup (see WORKGROUP_NAME_ALIASES)
         const isFromSelectedWorkgroup = contribution.task_sub_group && 
-          (contribution.task_sub_group.replace(/ /g, '-').toLowerCase()) === workgroup;
+          canonicalWorkgroupName(contribution.task_sub_group) === canonicalWorkgroupName(workgroup);
   
         if (formattedSelectedMonth === 'All months') {
           return isFromSelectedWorkgroup; // If "All months" is selected, only check workgroup

--- a/utils/txDenormalizer.js
+++ b/utils/txDenormalizer.js
@@ -1,3 +1,5 @@
+import { canonicalWorkgroupName } from './workgroupUtils';
+
 export async function txDenormalizer(txs) {
     async function generateReport() {
         let distributionsArray = [];
@@ -29,7 +31,7 @@ export async function txDenormalizer(txs) {
                     let taskTransformedDate = task_date || transformedDate;
 
                     let formattedTaskSubGroup = task_sub_group
-                        ? task_sub_group.replace(/ /g, '-').toLowerCase()
+                        ? canonicalWorkgroupName(task_sub_group)
                         : '';
 
                     if (contribution.distributions) {

--- a/utils/workgroupUtils.ts
+++ b/utils/workgroupUtils.ts
@@ -1,5 +1,25 @@
 // ../utils/workgroupUtils.ts
 
+/**
+ * When a workgroup was renamed in metadata without a DB migration, list every **non-canonical**
+ * normalized name here → the **canonical** name to use in reports, filters, and merged budget rows.
+ *
+ * - Keys: normalized only (lowercase, hyphens for spaces) — same form as after `canonicalWorkgroupName`’s base normalization.
+ * - Values: the single canonical subgroup name you want to keep.
+ * - Do not add `-wg` vs `-workgroup` pairs globally; only entries here are merged.
+ *
+ * @example
+ * ```ts
+ * {
+ *   'ai-ethics-workgroup': 'ai-ethics-wg',
+ *   'some-wg-old-slug': 'some-wg',
+ * }
+ * ```
+ */
+export const WORKGROUP_NAME_ALIASES: Readonly<Record<string, string>> = {
+  'ai-ethics-workgroup': 'ai-ethics-wg',
+};
+
 export interface WorkgroupData {
   monthlyTotals: {
     totalMonthly: Record<string, Record<string, number>>;
@@ -9,6 +29,8 @@ export interface WorkgroupData {
 
 export interface WorkgroupBudget {
   sub_group: string;
+  /** When true, row is shown under the collapsible "Archived" section; totals still include this subgroup. */
+  archived?: boolean | null;
   sub_group_data: {
     budgets: Record<string, Record<string, {
       initial: { AGIX: number };
@@ -19,6 +41,80 @@ export interface WorkgroupBudget {
       };
     }>>;
   };
+}
+
+/**
+ * Normalizes workgroup strings from metadata (spaces → dashes, lowercased), then applies
+ * {@link WORKGROUP_NAME_ALIASES} so duplicate names collapse to the chosen canonical form.
+ */
+export function canonicalWorkgroupName(name: string | null | undefined): string {
+  if (name == null || name === '') return '';
+  let current = String(name).trim().replace(/ /g, '-').toLowerCase();
+  // Follow alias chains (e.g. old-a → old-b → canonical); cap depth to avoid misconfiguration loops.
+  for (let i = 0; i < 8; i++) {
+    const next = WORKGROUP_NAME_ALIASES[current];
+    if (next === undefined) break;
+    current = next;
+  }
+  return current;
+}
+
+/** True if this distribution belongs to any selected workgroup, after canonical names. */
+export function distributionMatchesWorkgroupSelection(
+  taskSubGroup: string | undefined,
+  selectedWorkgroups: string[]
+): boolean {
+  if (selectedWorkgroups.includes('All workgroups')) return true;
+  if (!taskSubGroup || taskSubGroup.trim() === '') return false;
+  const canon = canonicalWorkgroupName(taskSubGroup);
+  return selectedWorkgroups.some((s) => canonicalWorkgroupName(s) === canon);
+}
+
+type QuarterBudget = WorkgroupBudget['sub_group_data']['budgets'][string][string];
+
+function mergeQuarterBudget(a: QuarterBudget | undefined, b: QuarterBudget | undefined): QuarterBudget {
+  return {
+    initial: { AGIX: (a?.initial?.AGIX ?? 0) + (b?.initial?.AGIX ?? 0) },
+    final: { AGIX: (a?.final?.AGIX ?? 0) + (b?.final?.AGIX ?? 0) },
+    reallocations: {
+      incoming: { AGIX: (a?.reallocations?.incoming?.AGIX ?? 0) + (b?.reallocations?.incoming?.AGIX ?? 0) },
+      outgoing: { AGIX: (a?.reallocations?.outgoing?.AGIX ?? 0) + (b?.reallocations?.outgoing?.AGIX ?? 0) },
+    },
+  };
+}
+
+/** Merges subgroup rows that {@link canonicalWorkgroupName} maps to the same key (see {@link WORKGROUP_NAME_ALIASES}). */
+export function mergeSubgroupRowsByCanonicalName(rows: WorkgroupBudget[]): WorkgroupBudget[] {
+  const map = new Map<string, WorkgroupBudget>();
+  for (const row of rows) {
+    const key = canonicalWorkgroupName(row.sub_group);
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, { ...row, sub_group: key });
+      continue;
+    }
+    const mergedBudgets: WorkgroupBudget['sub_group_data']['budgets'] = existing.sub_group_data?.budgets
+      ? JSON.parse(JSON.stringify(existing.sub_group_data.budgets))
+      : {};
+    const bBudgets = row.sub_group_data?.budgets ?? {};
+    for (const [year, quarters] of Object.entries(bBudgets)) {
+      if (!mergedBudgets[year]) {
+        mergedBudgets[year] = JSON.parse(JSON.stringify(quarters));
+      } else {
+        for (const [q, qd] of Object.entries(quarters)) {
+          const prev = mergedBudgets[year][q];
+          mergedBudgets[year][q] = mergeQuarterBudget(prev, qd);
+        }
+      }
+    }
+    map.set(key, {
+      ...existing,
+      sub_group: key,
+      archived: Boolean(existing.archived && row.archived),
+      sub_group_data: { budgets: mergedBudgets },
+    });
+  }
+  return Array.from(map.values());
 }
 
 export const getQuartersAndYearsFromMonths = (months: string[]) => {


### PR DESCRIPTION
- Introduced functionality to merge subgroup rows by canonical name in SnetDashboard, improving data processing.
- Updated WorkgroupBalances to differentiate between active and archived workgroups, allowing users to toggle visibility of archived entries.
- Modified styles for better UI representation of archived workgroups.
- Adjusted API to include archived status in subgroup data retrieval.